### PR TITLE
Restart grant wait for synchronous branch changes

### DIFF
--- a/zeroriscy_prefetch_buffer.sv
+++ b/zeroriscy_prefetch_buffer.sv
@@ -151,7 +151,7 @@ module zeroriscy_prefetch_buffer
           addr_valid   = 1'b1;
         end
 
-        if(instr_gnt_i)
+        if(instr_gnt_i & ~branch_i)
           NS = WAIT_RVALID;
         else
           NS = WAIT_GNT;


### PR DESCRIPTION
In case the signals `instr_gnt_i` and `branch_i` are asserted at the
same time, the branch request invalidates the current grant. Wait for
the next grant in order to be in sync with the data output of the fifo.